### PR TITLE
Add support for 'location' attribute

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -15,11 +15,12 @@ A Statamic V2 add-on that creates an iCal file that can be easily downloaded. Us
     end_date="{ end }" 
     summary="foo" 
     description="bar" 
+    location="baz" 
     url="myevents.com" }}">Add to your calendar</a>
 ```
 `start_date` & `end_date` could be a php date/time or a unix timestamp.
 
-`summary`, `description` and `url` are all optional.
+`summary`, `description`, `location` and `url` are all optional.
 
 ## LICENSE
 

--- a/Ical/IcalController.php
+++ b/Ical/IcalController.php
@@ -25,6 +25,7 @@ class IcalController extends Controller
             ->setDtStart($this->getCarbon(request('start_date')))
             ->setDtEnd($this->getCarbon(request('end_date')))
             ->setSummary(request('summary'))
+            ->setLocation(request('location'))
             ->setDescription(request('description'))
             ->setUrl(request('url'))
             ->addComponent($vAlarm);


### PR DESCRIPTION
This adds support for setting the string attribute [location](https://tools.ietf.org/html/rfc5545#section-3.8.1.7) via [$event->setLocation()](https://github.com/markuspoerschke/iCal/blob/master/src/Component/Event.php#L457). This does not add support for _geo_ functionality.