### PR TITLE
Fix syntax of 'trigger' duration passed to Alarm component

### DIFF
--- a/Ical/IcalController.php
+++ b/Ical/IcalController.php
@@ -13,11 +13,10 @@ class IcalController extends Controller
 {
     public function getDownload()
     {
-        // @todo this doesn't work
         $vAlarm = new Alarm();
         $vAlarm
             ->setAction(Alarm::ACTION_DISPLAY)
-            ->setTrigger('-P1H') // one hour before
+            ->setTrigger('-PT1H') // one hour before
             ->setDescription(request('summary'));
 
         $vEvent = new Event();


### PR DESCRIPTION
This fixes the syntax for the `trigger` property on the `Alarm` component in accordance with [the spec](https://en.wikipedia.org/wiki/ISO_8601#Durations). I tested this in Android and macOS clients and it seems to work now. 